### PR TITLE
Adapt colors for new colorscheme

### DIFF
--- a/apps/block_scout_web/assets/css/theme/_trustlines_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_trustlines_variables.scss
@@ -1,3 +1,57 @@
-$primary: #f05a55;
-$secondary: #fffaff;
+// general
+$primary: #0f3255;
+$secondary: #f5faff;
 $tertiary: #1e8cc3;
+
+// footer
+$footer-background-color: $primary;
+$footer-title-color: $secondary;
+$footer-text-color: $secondary;
+$footer-item-disc-color: $secondary;
+.footer-logo {
+  filter: brightness(0) invert(1);
+}
+
+// dashboard
+$dashboard-line-color-price: $tertiary; // price left border
+
+$dashboard-banner-chart-legend-value-color: $secondary; // chart labels
+
+$dashboard-stats-item-value-color: $secondary; // stat values
+
+$dashboard-stats-item-border-color: $secondary; // stat border
+
+$dashboard-banner-gradient-start: $primary; // gradient begin
+
+$dashboard-banner-gradient-end: lighten($primary, 5); // gradient end
+
+$dashboard-banner-network-plain-container-background-color: $tertiary; // stats bg
+
+// navigation
+.navbar {
+  box-shadow: 0px 0px 30px 0px rgba(21, 53, 80, 0.12);
+} // header shadow
+$header-icon-border-color-hover: $tertiary; // top border on hover
+$header-icon-color-hover: $primary; // nav icon on hover
+.dropdown-item:hover,
+.dropdown-item:focus {
+  background-color: $primary !important;
+} // dropdown item on hover
+
+// buttons
+$btn-line-bg: $secondary; // button bg
+$btn-line-color: $primary; // button border and font color && hover bg color
+$btn-copy-color: $primary; // btn copy
+$btn-qr-color: $primary; // btn qr-code
+
+//links & tile
+.tile a {
+  color: $primary !important;
+} // links color for badges
+.tile-type-block {
+  border-left: 4px solid $primary;
+} // tab active bg
+
+// card
+$card-background-1: $primary;
+$card-tab-active: $primary;

--- a/apps/block_scout_web/assets/css/theme/_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_variables.scss
@@ -1,24 +1,5 @@
-@import "theme/base_variables";
-@import "neutral_variables";
-// @import "dai_variables";
-// @import "ethereum_classic_variables";
-// @import "ethereum_variables";
-// @import "ether1_variables";
-// @import "expanse_variables";
-// @import "gochain_variables";
-// @import "goerli_variables";
-// @import "kovan_variables";
-// @import "lukso_variables";
-// @import "musicoin_variables";
-// @import "pirl_variables";
-// @import "poa_variables";
-// @import "posdao_variables";
-// @import "rinkeby_variables";
-// @import "ropsten_variables";
-// @import "social_variables";
-// @import "sokol_variables";
-// @import "tobalaba_variables";
-// @import "tomochain_variables";
+@import 'theme/base_variables';
+@import 'trustlines_variables';
 
 // responsive breakpoints
 $breakpoint-xs: 320px;


### PR DESCRIPTION
- Adapt the trustlines color scheme for the recent upstream changes.
- Switch to the colors of the Trustlines-Protocol instead of *-Network.
- Restore footer logo section from upstream.
- Remove dropdown to switch to other networks.

New/changed environment variables for the productive server:
```shell
SUBNETWORK="Laika Testnet"
LOGO=/images/trustlines_logo.svg
LOGO_FOOTER=/images/trustlines_logo_footer.svg
```

Related to brainbot-com/trustlines-meta#114
See also the recent PR #6