### PR TITLE
Bugfix/fix color theme for upstream

### DIFF
--- a/apps/block_scout_web/assets/css/theme/_trustlines_variables-non-critical.scss
+++ b/apps/block_scout_web/assets/css/theme/_trustlines_variables-non-critical.scss
@@ -1,0 +1,8 @@
+$primary: #0f3255;
+$dark-primary: #1e8cc3;
+$dark-primary-alternate: #1e8cc3;
+$secondary: #f5faff;
+$tertiary: #1e8cc3;
+
+// Fix the colors for the modal (like account QR code modal)
+$btn-line-color: $primary;

--- a/apps/block_scout_web/assets/css/theme/_trustlines_variables-non-critical.scss
+++ b/apps/block_scout_web/assets/css/theme/_trustlines_variables-non-critical.scss
@@ -1,8 +1,6 @@
+// general
 $primary: #0f3255;
-$dark-primary: #1e8cc3;
-$dark-primary-alternate: #1e8cc3;
 $secondary: #f5faff;
 $tertiary: #1e8cc3;
 
-// Fix the colors for the modal (like account QR code modal)
-$btn-line-color: $primary;
+$btn-line-color: $primary; // button border and font color && hover bg color

--- a/apps/block_scout_web/assets/css/theme/_trustlines_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_trustlines_variables.scss
@@ -1,9 +1,5 @@
-// general
-$primary: #0f3255;
-$dark-primary: #1e8cc3;
-$dark-primary-alternate: #1e8cc3;
-$secondary: #f5faff;
-$tertiary: #1e8cc3;
+// Avoid redundancy and re-use the non-critical variables.
+@import "trustlines_variables-non-critical";
 
 // footer
 $footer-background-color: $primary;

--- a/apps/block_scout_web/assets/css/theme/_trustlines_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_trustlines_variables.scss
@@ -1,5 +1,9 @@
-// Avoid redundancy and re-use the non-critical variables.
-@import "trustlines_variables-non-critical";
+// general
+$primary: #0f3255;
+$dark-primary: #1e8cc3;
+$dark-primary-alternate: #1e8cc3;
+$secondary: #f5faff;
+$tertiary: #1e8cc3;
 
 // footer
 $footer-background-color: $primary;

--- a/apps/block_scout_web/assets/css/theme/_trustlines_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_trustlines_variables.scss
@@ -1,5 +1,7 @@
 // general
 $primary: #0f3255;
+$dark-primary: #1e8cc3;
+$dark-primary-alternate: #1e8cc3;
 $secondary: #f5faff;
 $tertiary: #1e8cc3;
 
@@ -72,3 +74,10 @@ $btn-qr-color: $primary; // btn qr-code
 // card
 $card-background-1: $primary;
 $card-tab-active: $primary;
+
+// Fix the dark mode
+.dark-theme-applied {
+  .tile a {
+    color: $secondary !important;
+  }
+}

--- a/apps/block_scout_web/assets/css/theme/_variables-non-critical.scss
+++ b/apps/block_scout_web/assets/css/theme/_variables-non-critical.scss
@@ -1,5 +1,6 @@
 @import "theme/base_variables";
 @import "neutral_variables-non-critical";
+@import "trustlines_variables-non-critical";
 // @import "xusdt_variables-non-critical";
 // @import "dai_variables-non-critical";
 // @import "ethereum_classic_variables-non-critical";

--- a/apps/block_scout_web/assets/css/theme/_variables-non-critical.scss
+++ b/apps/block_scout_web/assets/css/theme/_variables-non-critical.scss
@@ -1,5 +1,5 @@
 @import "theme/base_variables";
-@import "neutral_variables-non-critical";
+// @import "neutral_variables-non-critical";
 @import "trustlines_variables-non-critical";
 // @import "xusdt_variables-non-critical";
 // @import "dai_variables-non-critical";

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -120,6 +120,11 @@
         </li>
       </ul>
       <!-- Dark mode changer was there -->
+      <button class="dark-mode-changer" id="dark-mode-changer">
+        <svg xmlns="http://www.w3.org/2000/svg" width="15" height="16">
+            <path fill="#9B62FF" fill-rule="evenodd" d="M14.88 11.578a.544.544 0 0 0-.599-.166 5.7 5.7 0 0 1-1.924.321c-3.259 0-5.91-2.632-5.91-5.866 0-1.947.968-3.759 2.59-4.849a.534.534 0 0 0-.225-.97A5.289 5.289 0 0 0 8.059 0C3.615 0 0 3.588 0 8s3.615 8 8.059 8c2.82 0 5.386-1.423 6.862-3.806a.533.533 0 0 0-.041-.616z"/>
+        </svg>
+      </button>
       <!-- Search navbar -->
       <%= if Application.get_env(:block_scout_web, BlockScoutWeb.WebRouter)[:enabled] do %>
         <div class="search-form d-lg-flex d-inline-block">


### PR DESCRIPTION
Closes: #16

**Builds on top of #22** because it moves the dark mode variables. Only the [last commit](https://github.com/trustlines-protocol/blockscout/commit/4fcc232315ff0cd24ca4a74f7c56b9fbba7a910a) is relevant.

A current version of this change can be inspected [here](http://167.172.186.95:4000/address/0xd3a22ca447f3f0b1b911b06034438bb2629af00e/transactions).
