### PR TITLE
Completely prevent calls to fetch_rates()

### DIFF
--- a/apps/explorer/lib/explorer/exchange_rates/exchange_rates.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/exchange_rates.ex
@@ -19,7 +19,7 @@ defmodule Explorer.ExchangeRates do
   def handle_info(:update, state) do
     Logger.debug(fn -> "Updating cached exchange rates" end)
 
-    fetch_rates()
+    # fetch_rates()
 
     {:noreply, state}
   end
@@ -42,7 +42,7 @@ defmodule Explorer.ExchangeRates do
   def handle_info({_ref, {:error, reason}}, state) do
     Logger.warn(fn -> "Failed to get exchange rates with reason '#{reason}'." end)
 
-    fetch_rates()
+    # fetch_rates()
 
     {:noreply, state}
   end


### PR DESCRIPTION
The error handling in exchange_rates.ex unconditionally reschedules a
call to get the exchange rates for each failed request. Since they
always do fail, each request will end up in an 'infinite loop'.

Since blockscout will schedule new exchange rates calls to be done,
those 'infinite loops' pile up, since we will never have a successful
call.

We end up with lots of processes basically only waiting and spamming
our logs.
