### PR TITLE
Replace default root README with custom version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,29 @@
 <p align="center">
-  <a href="https://blockscout.com">
+  <a href="https://explore.tlbc.trustlines.foundation/">
     <img width="200" src="https://blockscout.com/poa/core/android-chrome-192x192.png" \>
   </a>
 </p>
 
 <h1 align="center">BlockScout</h1>
-<p align="center">Blockchain Explorer for inspecting and analyzing EVM Chains.</p>
-<div align="center">
+<p align="center">
+  Blockchain Explorer for inspecting and analyzing chains of the Trustlines Foundation
+</p>
 
-[![CircleCI](https://circleci.com/gh/poanetwork/blockscout.svg?style=svg&circle-token=f8823a3d0090407c11f87028c73015a331dbf604)](https://circleci.com/gh/poanetwork/blockscout) [![Coverage Status](https://coveralls.io/repos/github/poanetwork/blockscout/badge.svg?branch=master)](https://coveralls.io/github/poanetwork/blockscout?branch=master) [![Join the chat at https://gitter.im/poanetwork/blockscout](https://badges.gitter.im/poanetwork/blockscout.svg)](https://gitter.im/poanetwork/blockscout?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+This is a fork of the [origin Blockscout
+project](https://github.com/poanetwork/blockscout). It is an adjusted version
+for the purpose of the [Trustlines
+Blockchain](https://explore.tlbc.trustlines.foundation/) and the
+[Laika](https://explore.laika.trustlines.foundation/) test network. Such include
+adoptions of the view and layout focusing on the needs of the Trustlines
+Foundation.
 
-</div>
-
-BlockScout provides a comprehensive, easy-to-use interface for users to view, confirm, and inspect transactions on EVM (Ethereum Virtual Machine) blockchains. This includes the POA Network, xDai Chain, Ethereum Classic and other **Ethereum testnets, private networks and sidechains**.
-
-See our [project documentation](https://docs.blockscout.com/) for detailed information and setup instructions.
-
-Visit the [POA BlockScout forum](https://forum.poa.network/c/blockscout) for FAQs, troubleshooting, and other BlockScout related items. You can also post and answer questions here.
-
-You can also access the dev chatroom on our [Gitter Channel](https://gitter.im/poanetwork/blockscout).
-
-## About BlockScout
-
-BlockScout is an Elixir application that allows users to search transactions, view accounts and balances, and verify smart contracts on the Ethereum network including all forks and sidechains.
-
-Currently available full-featured block explorers (Etherscan, Etherchain, Blockchair) are closed systems which are not independently verifiable.  As Ethereum sidechains continue to proliferate in both private and public settings, transparent, open-source tools are needed to analyze and validate transactions.
-
-## Supported Projects
-
-BlockScout supports a number of projects. Hosted instances include POA Network, xDai Chain, Ethereum Classic, Sokol & Kovan testnets, and other EVM chains. 
-
-- [List of hosted mainnets, testnets, and additional chains using BlockScout](https://docs.blockscout.com/for-projects/supported-projects)
-- [Hosted instance versions](https://docs.blockscout.com/about/use-cases/hosted-blockscout)
-
-
-## Getting Started
-
-See the [project documentation](https://docs.blockscout.com/) for instructions:
-- [Requirements](https://docs.blockscout.com/for-developers/information-and-settings/requirements)
-- [Ansible deployment](https://docs.blockscout.com/for-developers/ansible-deployment)
-- [Manual deployment](https://docs.blockscout.com/for-developers/manual-deployment)
-- [ENV variables](https://docs.blockscout.com/for-developers/information-and-settings/env-variables)
-- [Configuration options](https://docs.blockscout.com/for-developers/configuration-options)
-
-
-## Acknowledgements
-
-We would like to thank the [EthPrize foundation](http://ethprize.io/) for their funding support.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution and pull request protocol. We expect contributors to follow our [code of conduct](CODE_OF_CONDUCT.md) when submitting code or comments.
+For further instructions of setup, usage, and more, please checkout [the
+official documentation](https://docs.blockscout.com/) by Blockscout.
 
 ## License
 
-[![License: GPL v3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![License: GPL
+v3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
-This project is licensed under the GNU General Public License v3.0. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the GNU General Public License v3.0. See the
+[LICENSE](LICENSE) file for details.


### PR DESCRIPTION
This is a fork with adjustments for the Trustlines Foundation and their
blockchains. It is not a fork to work on features or bugs and open PRs
back to the origin. Also do links and shields (like CI builds) not refer
to the correct sources. All of the official documentation and more can
be found at their project.This should be reflected by the README
displayed to the user visiting this project.

This should not bother future upstream merges. The whole file can remain
as it is and must not care about conflicts or changes.

Related to: trustlines-network/project#798