### PR TITLE
Fix CSP issues for the Matomo statistics script

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/csp_header.ex
+++ b/apps/block_scout_web/lib/block_scout_web/csp_header.ex
@@ -13,7 +13,7 @@ defmodule BlockScoutWeb.CSPHeader do
       "content-security-policy" => "\
         connect-src 'self' #{websocket_endpoints(conn)}; \
         default-src 'self';\
-        script-src 'self' 'unsafe-inline' 'unsafe-eval';\
+        script-src 'self' 'unsafe-inline' 'unsafe-eval' *;\
         style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com;\
         img-src 'self' * data:;\
         font-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.gstatic.com data:;\


### PR DESCRIPTION
Closes: #32

Tested with @Smokyish and disabled whitelisting on server side. Thereby we could test
it this time already without the correct domain, bust just a Droplet for test
purpose. The script gets loaded now (maybe must be enabled by privacy plugins)
and reports data to the stats server.