### PR TITLE
Fix wrong header hight on safari

### DIFF
--- a/apps/block_scout_web/assets/css/app.scss
+++ b/apps/block_scout_web/assets/css/app.scss
@@ -124,6 +124,8 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "theme/custom_contracts/dark-forest-theme";
 @import "theme/custom_contracts/circles-theme";
 
+@import "trustlines-overrides";
+
 :export {
   dashboardBannerChartAxisFontColor: $dashboard-banner-chart-axis-font-color;
   dashboardLineColorMarket: $dashboard-line-color-market;

--- a/apps/block_scout_web/assets/css/trustlines-overrides.scss
+++ b/apps/block_scout_web/assets/css/trustlines-overrides.scss
@@ -1,0 +1,3 @@
+.navbar-brand .navbar-logo {
+ height: 50px;
+}


### PR DESCRIPTION
It seems that safari has troubles figuring out the eheight of an image when the image is an .svg. 